### PR TITLE
Fix logrus import path

### DIFF
--- a/cmd/maildiranasaurus/root.go
+++ b/cmd/maildiranasaurus/root.go
@@ -11,7 +11,7 @@
 package main
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
Little fix for  "github.com/sirupsen/logrus". 

It should be lower case for import path of logrus, otherwise build fails
:)

Excellent work on go-guerrilla and this project 👍 Thanks a lot